### PR TITLE
Fix for model bias

### DIFF
--- a/SD_rebasin_merge.py
+++ b/SD_rebasin_merge.py
@@ -31,6 +31,8 @@ step = alpha/iterations
 
 if args.usefp16:
     print("Using half precision")
+else:
+    print("Using full precision")
 
 permutation_spec = sdunet_permutation_spec()
 
@@ -63,9 +65,9 @@ for x in range(iterations):
 
     # Replace theta_0 with a permutated version using model A and B    
     first_permutation, y = weight_matching(permutation_spec, flatten_params(model_a), theta_0, usefp16=args.usefp16)
-    theta_0 = apply_permutation(permutation_spec, first_permutation, theta_0)
+    theta_3 = apply_permutation(permutation_spec, first_permutation, theta_0)
     second_permutation, z = weight_matching(permutation_spec, flatten_params(model_b), theta_0, usefp16=args.usefp16)
-    theta_3= apply_permutation(permutation_spec, second_permutation, theta_0)
+    theta_4= apply_permutation(permutation_spec, second_permutation, theta_0)
 
     new_alpha = y / (y + z)
     print(new_alpha)
@@ -73,7 +75,7 @@ for x in range(iterations):
     # Weighted sum of the permutations
     for key in theta_0.keys():
         if "model" in key and key in theta_1:
-            theta_0[key] = (1 - new_alpha) * (theta_0[key]) + (new_alpha) * (theta_3[key])
+            theta_0[key] = (1 - new_alpha) * (theta_3[key]) + (new_alpha) * (theta_4[key])
 
 output_file = f'{args.output}.ckpt'
 

--- a/SD_rebasin_merge.py
+++ b/SD_rebasin_merge.py
@@ -7,7 +7,7 @@ from weight_matching import sdunet_permutation_spec, weight_matching, apply_perm
 
 
 parser = argparse.ArgumentParser(description= "Merge two stable diffusion models with git re-basin")
-parser.add_argument("--model_a", type=str, help="Path to model a", default="cpu", required=False)
+parser.add_argument("--model_a", type=str, help="Path to model a")
 parser.add_argument("--model_b", type=str, help="Path to model b")
 parser.add_argument("--device", type=str, help="Device to use, defaults to cpu", default="cpu", required=False)
 parser.add_argument("--output", type=str, help="Output file name, without extension", default="merged", required=False)
@@ -62,15 +62,18 @@ for x in range(iterations):
     print("FINDING PERMUTATIONS")
 
     # Replace theta_0 with a permutated version using model A and B    
-    first_permutation = weight_matching(permutation_spec, flatten_params(model_a), theta_0, usefp16=args.usefp16)
+    first_permutation, y = weight_matching(permutation_spec, flatten_params(model_a), theta_0, usefp16=args.usefp16)
     theta_0 = apply_permutation(permutation_spec, first_permutation, theta_0)
-    second_permutation = weight_matching(permutation_spec, flatten_params(model_b), theta_0, usefp16=args.usefp16)
-    theta_0 = apply_permutation(permutation_spec, second_permutation, theta_0)
+    second_permutation, z = weight_matching(permutation_spec, flatten_params(model_b), theta_0, usefp16=args.usefp16)
+    theta_3= apply_permutation(permutation_spec, second_permutation, theta_0)
 
-    # # Weighted sum of the permutations
-    # for key in theta_0.keys():
-    #     if "model" in key and key in theta_1:
-    #         theta_0[key] = (1 - (new_alpha)) * (theta_0[key]) + (new_alpha) * (theta_3[key])
+    new_alpha = y / (y + z)
+    print(new_alpha)
+
+    # Weighted sum of the permutations
+    for key in theta_0.keys():
+        if "model" in key and key in theta_1:
+            theta_0[key] = (1 - new_alpha) * (theta_0[key]) + (new_alpha) * (theta_3[key])
 
 output_file = f'{args.output}.ckpt'
 

--- a/weight_matching.py
+++ b/weight_matching.py
@@ -3,8 +3,8 @@ from re import L
 from typing import NamedTuple
 import torch
 from scipy.optimize import linear_sum_assignment
-import time
 from random import shuffle
+
 rngmix = lambda rng, x: random.fold_in(rng, hash(x))
 
 class PermutationSpec(NamedTuple):
@@ -784,11 +784,13 @@ def apply_permutation(ps: PermutationSpec, perm, params):
 
 def weight_matching(ps: PermutationSpec, params_a, params_b, max_iter=5, init_perm=None, usefp16=False):
   """Find a permutation of `params_b` to make them match `params_a`."""
-  special_layers = ["P_bg358", "P_bg324", "P_bg337"]
+  special_layers = ["P_bg358", "P_bg324", "P_bg337", "P_bg355"]
   perm_sizes = {p: params_a[axes[0][0]].shape[axes[0][1]] for p, axes in ps.perm_to_axes.items()}
   perm = dict()
   perm = {p: torch.arange(n) for p, n in perm_sizes.items()} if init_perm is None else init_perm
   perm_names = list(perm.keys())
+  sum = 0
+  number = 0
   if usefp16:
     for iteration in range(max_iter):
       progress = False
@@ -814,6 +816,8 @@ def weight_matching(ps: PermutationSpec, params_a, params_b, max_iter=5, init_pe
           newL = torch.vdot(torch.flatten(A), torch.flatten(torch.eye(n)[ci, :]).half())
           
           if newL - oldL != 0:
+            sum += abs((newL-oldL).item())
+            number += 1
             print(f"{p}: {newL - oldL}")
 
           progress = progress or newL > oldL + 1e-12
@@ -822,8 +826,12 @@ def weight_matching(ps: PermutationSpec, params_a, params_b, max_iter=5, init_pe
         
       if not progress:
         break
-
-    return perm
+    
+    if number > 0:
+      average = sum / number
+    else:
+      average = 0
+    return (perm, average)
 
   else:
     for iteration in range(max_iter):
@@ -845,7 +853,12 @@ def weight_matching(ps: PermutationSpec, params_a, params_b, max_iter=5, init_pe
         
         oldL = torch.vdot(torch.flatten(A), torch.flatten(torch.eye(n)[perm[p].long()]))
         newL = torch.vdot(torch.flatten(A), torch.flatten(torch.eye(n)[ci, :]))
-        print(f"{iteration}/{p}: {newL - oldL}")
+
+        if newL - oldL != 0:
+            sum += abs((newL-oldL).item())
+            number += 1
+            print(f"{p}: {newL - oldL}")
+
         progress = progress or newL > oldL + 1e-12
 
         perm[p] = torch.Tensor(ci)
@@ -853,7 +866,12 @@ def weight_matching(ps: PermutationSpec, params_a, params_b, max_iter=5, init_pe
       if not progress:
         break
 
-    return perm
+    if number > 0:
+      average = sum / number
+    else:
+      average = 0
+    return (perm, average)
+
 
 def test_weight_matching():
   """If we just have a single hidden layer then it should converge after just one step."""


### PR DESCRIPTION
Calculates average of newL - oldL for each permutation. Then takes the weighted sum of the two permutations using the difference in average newL - oldL. Seems to be a little better than the original method with the downside of being slightly slower. 

I can't test this right now, so please let me know if it works better.